### PR TITLE
Add Terraform variables, sample tfvars, and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ crash.*.log
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
+!terraform.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # azure-vm-automation-arena
 Infrastructure-as-code showdown: Azure, Terraform, Ansible, automation and domination.
+
+## Terraform variables
+Input variables for the deployment are defined in `variables.tf`.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `resource_group_name` | Name of the resource group in which resources will be created. | n/a |
+| `location` | Azure region for all resources. | `eastus` |
+| `vm_name` | Name of the virtual machine. | n/a |
+| `admin_username` | Admin username for the VM. | n/a |
+| `admin_password` | Admin password for the VM (sensitive). | n/a |
+| `vm_size` | Size of the virtual machine. | `Standard_B1s` |
+
+Update the provided `terraform.tfvars` file with values for these variables or pass them via the CLI.
+
+Example values:
+
+```hcl
+resource_group_name = "rg-example"
+vm_name             = "vm-example"
+admin_username      = "azureuser"
+admin_password      = "P@ssw0rd123!"
+```
+
+Run Terraform with:
+
+```bash
+terraform init
+terraform apply
+```

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,6 @@
+resource_group_name = "rg-example"
+location            = "eastus"
+vm_name             = "vm-example"
+admin_username      = "azureuser"
+admin_password      = "P@ssw0rd123!"
+vm_size             = "Standard_B1s"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,32 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group in which resources will be created."
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for all resources."
+  default     = "eastus"
+}
+
+variable "vm_name" {
+  type        = string
+  description = "Name of the virtual machine."
+}
+
+variable "admin_username" {
+  type        = string
+  description = "Admin username for the VM."
+}
+
+variable "admin_password" {
+  type        = string
+  description = "Admin password for the VM."
+  sensitive   = true
+}
+
+variable "vm_size" {
+  type        = string
+  description = "Size of the virtual machine."
+  default     = "Standard_B1s"
+}


### PR DESCRIPTION
## Summary
- define Terraform input variables for VM provisioning
- document variables and usage in README
- provide sample terraform.tfvars and adjust gitignore to include it

## Testing
- `terraform fmt -recursive`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6890ca3d4e90832a864301590c1f3cdb