### PR TITLE
Use variables in main Terraform configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,8 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "main" {
-  name     = "rg-automation-arena"
-  location = "East US"
+  name     = var.resource_group_name
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "main" {
@@ -43,12 +43,12 @@ resource "azurerm_public_ip" "main" {
 }
 
 resource "azurerm_windows_virtual_machine" "main" {
-  name                = "winvm-arena"
+  name                = var.vm_name
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  size                = "Standard_DS1_v2"
-  admin_username      = "azureadmin"
-  admin_password      = "StrongP@ssw0rd123"  # ⚠️ Replace this or use Key Vault
+  size                = var.vm_size
+  admin_username      = var.admin_username
+  admin_password      = var.admin_password
 
   network_interface_ids = [
     azurerm_network_interface.main.id,
@@ -66,7 +66,7 @@ resource "azurerm_windows_virtual_machine" "main" {
     version   = "latest"
   }
 
-  computer_name  = "ArenaVM"
+  computer_name      = var.vm_name
   provision_vm_agent = true
 }
 


### PR DESCRIPTION
## Summary
- Reference Terraform variables for resource group and VM settings in `main.tf`.

## Testing
- `terraform fmt -check`
- `terraform init` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_6890cfded0d4832a8e71173337935615